### PR TITLE
Show commit date alongside version hash in UI footer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,7 @@ export default function App() {
           ))}
         </tbody>
       </table>
-      <footer className="version">v{__COMMIT_HASH__}</footer>
+      <footer className="version">v{__COMMIT_HASH__} · {__COMMIT_DATE__}</footer>
     </div>
   )
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,11 +3,13 @@ import react from '@vitejs/plugin-react'
 import { execSync } from 'child_process'
 
 const commitHash = execSync('git rev-parse --short HEAD').toString().trim()
+const commitDate = execSync('git log -1 --format=%cd --date=format:"%Y-%m-%d %H:%M"').toString().trim()
 
 export default defineConfig({
   plugins: [react()],
   define: {
     __COMMIT_HASH__: JSON.stringify(commitHash),
+    __COMMIT_DATE__: JSON.stringify(commitDate),
   },
   server: {
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- Extends the version footer to display the commit date and time next to the commit hash
- Date is resolved at build time via `git log`, same approach as the existing hash
- Footer now shows e.g. `v98c80e3 · 2026-04-22 21:15`

Closes #2

## Test plan
- [ ] Open the app and verify the footer shows both hash and date
- [ ] Confirm the date matches the latest commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)