### PR TITLE
Show version and build timestamp in footer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,7 @@ export default function App() {
           ))}
         </tbody>
       </table>
-      <footer className="version">v{__COMMIT_HASH__} · {__COMMIT_DATE__}</footer>
+      <footer className="version">v{__COMMIT_HASH__} · built {__BUILD_TIME__}</footer>
     </div>
   )
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,13 +3,13 @@ import react from '@vitejs/plugin-react'
 import { execSync } from 'child_process'
 
 const commitHash = execSync('git rev-parse --short HEAD').toString().trim()
-const commitDate = execSync('git log -1 --format=%cd --date=format:"%Y-%m-%d %H:%M"').toString().trim()
+const buildTime = new Date().toLocaleString('sv-SE', { timeZone: 'Europe/Stockholm', hour12: false }).replace('T', ' ')
 
 export default defineConfig({
   plugins: [react()],
   define: {
     __COMMIT_HASH__: JSON.stringify(commitHash),
-    __COMMIT_DATE__: JSON.stringify(commitDate),
+    __BUILD_TIME__: JSON.stringify(buildTime),
   },
   server: {
     allowedHosts: true,


### PR DESCRIPTION
## Summary

Closes #4.

- Replaces the git commit date in the footer with the actual **build timestamp** — the moment Vite processed the config, injected as a static string at build time
- Keeps the commit hash as the version identifier
- Footer now reads: `v<hash> · built <YYYY-MM-DD HH:MM>`

## What changed

- `vite.config.js` — swaps `__COMMIT_DATE__` (git log date) for `__BUILD_TIME__` (`new Date()` at build time)
- `App.jsx` — updates the footer to use `__BUILD_TIME__` with a `built` label

## Test plan

- [ ] Footer shows the correct commit hash
- [ ] Footer shows a build timestamp that matches when the dev server / build was last started
- [ ] Visible on mobile without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)