### PR TITLE
Change Start Work button color from pink to blue

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,7 +27,7 @@ h1 {
   padding: 16px;
   font-size: 1.2rem;
   font-weight: bold;
-  background: #ec4899;
+  background: #3b82f6;
   color: white;
   border: none;
   border-radius: 12px;
@@ -36,7 +36,7 @@ h1 {
 }
 
 .btn-start:hover {
-  background: #db2777;
+  background: #2563eb;
 }
 
 table {


### PR DESCRIPTION
## Summary
- Changes the "Start Work" button background from pink (`#ec4899`) to blue (`#3b82f6`)
- Updates the hover state from dark pink (`#db2777`) to dark blue (`#2563eb`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)