### PR TITLE
Add Stop Work button

### DIFF
--- a/backend/src/main/java/com/worklog/SessionController.java
+++ b/backend/src/main/java/com/worklog/SessionController.java
@@ -2,7 +2,9 @@ package com.worklog;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,6 +26,17 @@ public class SessionController {
     public Session start() {
         log.info("Start button pressed — creating new session");
         return repository.save(new Session(LocalDateTime.now()));
+    }
+
+    @PostMapping("/{id}/stop")
+    public Session stop(@PathVariable Long id) {
+        log.info("Stop button pressed for session {}", id);
+        return repository.findById(id)
+                .map(session -> {
+                    session.setStopTime(LocalDateTime.now());
+                    return repository.save(session);
+                })
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
     }
 
     @GetMapping

--- a/backend/src/test/java/com/worklog/SessionControllerTest.java
+++ b/backend/src/test/java/com/worklog/SessionControllerTest.java
@@ -6,11 +6,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,5 +71,35 @@ class SessionControllerTest {
 
         // Then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should set stopTime and return updated session when stop is called")
+    void shouldSetStopTimeAndReturnUpdatedSessionWhenStopIsCalled() {
+        // Given
+        Long sessionId = 1L;
+        Session session = new Session(LocalDateTime.of(2026, 4, 24, 9, 0));
+        given(repository.findById(sessionId)).willReturn(Optional.of(session));
+        given(repository.save(any(Session.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // When
+        Session result = controller.stop(sessionId);
+
+        // Then
+        assertThat(result.getStopTime()).isNotNull();
+        then(repository).should().save(session);
+    }
+
+    @Test
+    @DisplayName("Should throw 404 when stopping a session that does not exist")
+    void shouldThrow404WhenStoppingSessionThatDoesNotExist() {
+        // Given
+        Long sessionId = 99L;
+        given(repository.findById(sessionId)).willReturn(Optional.empty());
+
+        // When / Then
+        assertThatThrownBy(() -> controller.stop(sessionId))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Session not found");
     }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -21,22 +21,43 @@ h1 {
   margin-bottom: 24px;
 }
 
-.btn-start {
-  display: block;
-  width: 100%;
+.btn-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.btn-start,
+.btn-stop {
+  flex: 1;
   padding: 16px;
   font-size: 1.2rem;
   font-weight: bold;
-  background: #eab308;
   color: white;
   border: none;
   border-radius: 12px;
   cursor: pointer;
-  margin-bottom: 32px;
+}
+
+.btn-start {
+  background: #dc2626;
 }
 
 .btn-start:hover {
-  background: #ca8a04;
+  background: #b91c1c;
+}
+
+.btn-stop {
+  background: #16a34a;
+}
+
+.btn-stop:hover:not(:disabled) {
+  background: #15803d;
+}
+
+.btn-stop:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
 }
 
 table {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,13 +20,31 @@ export default function App() {
     fetch(`${API}/start`, { method: 'POST' })
       .then(fetchSessions)
 
+  const handleStop = (id) =>
+    fetch(`${API}/${id}/stop`, { method: 'POST' })
+      .then(fetchSessions)
+
+  const hasActiveSession = sessions.some(s => !s.stopTime)
+
   return (
     <div className="app">
       <h1>Worklog</h1>
 
-      <button className="btn-start" onClick={handleStart}>
-        Start Work
-      </button>
+      <div className="btn-row">
+        <button className="btn-start" onClick={handleStart}>
+          Start Work
+        </button>
+        <button
+          className="btn-stop"
+          onClick={() => {
+            const active = sessions.find(s => !s.stopTime)
+            if (active) handleStop(active.id)
+          }}
+          disabled={!hasActiveSession}
+        >
+          Stop Work
+        </button>
+      </div>
 
       <table>
         <thead>


### PR DESCRIPTION
## Summary

- Added `POST /api/sessions/{id}/stop` backend endpoint that sets `stopTime` and returns the updated session (404 if not found)
- Added **Stop Work** button to the UI — shown next to Start Work, disabled when no active session exists
- Stops the most recent active session on click
- Added 2 new JUnit 5 tests (BDDMockito style) for the stop endpoint

Closes #10

## Test plan

- [ ] Start a session — Stop Work button becomes enabled
- [ ] Click Stop Work — session row shows stop time and duration
- [ ] Stop Work is disabled when no active session
- [ ] Verify on mobile browser (phone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)